### PR TITLE
Default switch not needed...

### DIFF
--- a/Tombatron.Results.All/Tombatron.Results.All.csproj
+++ b/Tombatron.Results.All/Tombatron.Results.All.csproj
@@ -7,9 +7,9 @@
     <Authors>Tom Hanks (tombatron)</Authors>
     <Description>This package combines the Tombatron.Results and Tombatron.Results.Analyzers package into one convenient place.</Description>
 
-    <Version>1.1.0</Version>
-    <FileVersion>1.1.0</FileVersion>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <Version>1.2.0</Version>
+    <FileVersion>1.2.0</FileVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
@@ -73,7 +73,7 @@ public class Examples
         {
             Ok<string> => "ok",
             Error<string> => "error",
-            _ => "whoa"
+            //_ => "whoa"
         };
 
 
@@ -120,5 +120,17 @@ public class Examples
         return justOn;
         // No compiler error because I'm immediately returning the result. 
         //return Result<string>.Ok("hello world");
+    }
+
+    public Result<string> DefaultSwitchCaseIsntNeeded()
+    {
+        // No warning on the switch statement because there are only two cases to handle.
+        var workResult = DoWork();
+        
+        return workResult switch
+        {
+            Ok<string> ok => ok,
+            Error<string> error => error
+        };
     }
 }

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
@@ -60,7 +60,7 @@ public class Examples
         {
             Ok<string> => "ok",
             Error<string> => "error",
-            _ => "whatever"
+            //_ => "whatever"
         };
     }
 

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/NonGenericExamples.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/NonGenericExamples.cs
@@ -60,7 +60,7 @@ public class NonGenericExamples
         {
             Ok => "ok",
             Error => "error",
-            _ => "whatever"
+            //_ => "whatever" <-- Don't need this since I've suppressed CS8509.
         };
     }
 

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/ResultHandlingAnalyzerTests.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/ResultHandlingAnalyzerTests.cs
@@ -309,4 +309,34 @@ public class ResultHandlingAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync<ResultHandlingAnalyzer>(testCode);        
     }        
+    
+    [Fact]
+    public async Task SuppressCompilerWarningForExhaustiveResultSwitch()
+    {
+        const string testCode = @"
+        using System;
+        using Tombatron.Results;
+
+        class Program
+        {
+            void Main()
+            {
+                Result<int> result = SomeMethod();
+
+                var handledValue = result switch
+                {
+                    Ok<int> ok => ""ok"",
+                    Error<int> err => ""err""
+                };
+
+                Console.WriteLine(handledValue);
+            }
+
+            Result<int> SomeMethod() => new Ok<int>(42);
+        }
+        ";
+
+        // Test that CS8509 is suppressed by our suppressor
+        await VerifyCS.VerifySuppressionAsync<ResultTypeSwitchSuppressor>(testCode, "CS8509");        
+    }    
 }

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/AnalyzerReleases.Shipped.md
@@ -2,7 +2,8 @@
 
 ### New Rules
 
-| Rule ID  | Category | Severity | Notes                                                                      |
-|----------|----------|----------|----------------------------------------------------------------------------|
-| TBTRA001 | Usage    | Error    | When using Tombatron.Results.Result<T> you must handle Ok<T> and Error<T>. |
-| TBTRA002 | Usage    | Error    | When using Tombatron.Result.Result you must handle Ok and Error.           | 
+| Rule ID  | Category    | Severity | Notes                                                                      |
+|----------|-------------|----------|----------------------------------------------------------------------------|
+| TBTRA001 | Usage       | Error    | When using Tombatron.Results.Result<T> you must handle Ok<T> and Error<T>. |
+| TBTRA002 | Usage       | Error    | When using Tombatron.Result.Result you must handle Ok and Error.           |
+| TBTRA901 | Suppression | Hidden   | Suppresses CS8509 when switch expression exhaustively handles Result<T>.   | 

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultHandlingAnalyzer.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultHandlingAnalyzer.cs
@@ -40,8 +40,10 @@ public class ResultHandlingAnalyzer : DiagnosticAnalyzer
                 var parentBlock = variable.Ancestors().OfType<BlockSyntax>().FirstOrDefault();
 
                 if (parentBlock == null)
+                {
                     // I guess we're not in a code block...
                     continue;
+                }
 
                 // Look for switches or if-statements handling the variable that we detected up above. 
                 var references = parentBlock.DescendantNodes()

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressor.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressor.cs
@@ -6,12 +6,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Tombatron.Results.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class ResultTypeSwitchSuppressor : DiagnosticSuppressor
+public partial class ResultTypeSwitchSuppressor : DiagnosticSuppressor
 {
     private static readonly SuppressionDescriptor SwitchExpressionExhaustiveRule = new(
-        id: "TBTRA901",
-        suppressedDiagnosticId: "CS8509",
-        justification: "Switch expression is exhaustive for Tombatron.Results.Result type, otherwise there's an error.");
+        id: SuppressorId,
+        suppressedDiagnosticId: SuppressedId,
+        justification: Justification);
     
     public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions =>
         ImmutableArray.Create(SwitchExpressionExhaustiveRule);
@@ -20,7 +20,7 @@ public class ResultTypeSwitchSuppressor : DiagnosticSuppressor
     {
         foreach (var diagnostic in context.ReportedDiagnostics)
         {
-            if (diagnostic.Id != SwitchExpressionExhaustiveRule.Id)
+            if (diagnostic.Id != SwitchExpressionExhaustiveRule.SuppressedDiagnosticId)
             {
                 continue;
             }

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressor.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressor.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Tombatron.Results.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ResultTypeSwitchSuppressor : DiagnosticSuppressor
+{
+    private static readonly SuppressionDescriptor SwitchExpressionExhaustiveRule = new(
+        id: "TBTRA901",
+        suppressedDiagnosticId: "CS8509",
+        justification: "Switch expression is exhaustive for Tombatron.Results.Result type, otherwise there's an error.");
+    
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions =>
+        ImmutableArray.Create(SwitchExpressionExhaustiveRule);
+    
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        foreach (var diagnostic in context.ReportedDiagnostics)
+        {
+            if (diagnostic.Id != SwitchExpressionExhaustiveRule.Id)
+            {
+                continue;
+            }
+            
+            var syntaxTree = diagnostic.Location.SourceTree;
+
+            if (syntaxTree is null)
+            {
+                continue;
+            }
+            
+            var root = syntaxTree.GetRoot(context.CancellationToken);
+            
+            var switchExpress = root.FindNode(diagnostic.Location.SourceSpan) as SwitchExpressionSyntax;
+
+            if (switchExpress is null)
+            {
+                continue;
+            }
+            
+            var semanticModel = context.GetSemanticModel(syntaxTree);
+            var switchExpressionType = semanticModel.GetTypeInfo(switchExpress.GoverningExpression).Type;
+
+            if (switchExpressionType is not null && IsResultType(switchExpressionType))
+            {
+                context.ReportSuppression(Suppression.Create(SwitchExpressionExhaustiveRule, diagnostic));
+            }
+        }
+    }
+
+    private static bool IsResultType(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol namedTypeSymbol)
+        {
+            var fullName = namedTypeSymbol.ToDisplayString();
+
+            return fullName.StartsWith("Tombatron.Results.Result");
+        }
+
+        return false;
+    }
+}

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressorConstants.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/ResultTypeSwitchSuppressorConstants.cs
@@ -1,0 +1,9 @@
+﻿namespace Tombatron.Results.Analyzers
+{
+    public partial class ResultTypeSwitchSuppressor
+    {
+        private const string SuppressorId = "TBTRA901";
+        private const string SuppressedId = "CS8509";
+        private const string Justification = "Switch expression is exhaustive for Tombatron.Results.Result type, otherwise there's an error.";
+    }
+}

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.csproj
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.csproj
@@ -15,9 +15,9 @@
         <Authors>Tom Hanks (tombatron)</Authors>
         <Description>This package contains analyzers for use with the Tombatron.Results Nuget package, and assures that the expected usage of the project is enforced. </Description>
         
-        <Version>1.1.0</Version>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
-        <FileVersion>1.1.0</FileVersion>
+        <Version>1.2.0</Version>
+        <AssemblyVersion>1.2.0</AssemblyVersion>
+        <FileVersion>1.2.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,8 +25,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -58,9 +58,6 @@
 
     <ItemGroup>
       <!-- Add the DLL produced by the current project to the NuGet package -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll"
-            Pack="true"
-            PackagePath="analyzers/dotnet/cs"
-            Visible="false" />
+      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>    
 </Project>

--- a/Tombatron.Results/Tombatron.Results.csproj
+++ b/Tombatron.Results/Tombatron.Results.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         
-        <Version>1.1.0</Version>
-        <FileVersion>1.1.0</FileVersion>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
+        <Version>1.2.0</Version>
+        <FileVersion>1.2.0</FileVersion>
+        <AssemblyVersion>1.2.0</AssemblyVersion>
         
         <Title>Tombatron.Results</Title>
         <Authors>Tom Hanks (tombatron)</Authors>


### PR DESCRIPTION
If you are switching on a Tombatron.Results.Result type you won't need to define a default handler. 