### PR TITLE
Suggestion: Allowing the Error type to accept multiple error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,30 @@ The next method is `Result<T>.Error(string message)`. You'll use this method to 
 var errorValue = Result<string>.Error("Oh noes!");
 ```
 
+For scenarios where you need to report multiple errors at once, you can use `Result<T>.Error(string[] messages)`:
+
+**Example:**
+
+```csharp
+var multipleErrors = Result<string>.Error(new[] { 
+    "Validation failed for field 'Name'", 
+    "Validation failed for field 'Email'", 
+    "Validation failed for field 'Phone'" 
+});
+```
+
 Again, like the `Ok<T>` class, we can directly construct the `Error<T>` class instead of using the static factory method. 
 
 **Example:**
 
 ```csharp
 var errorValue = new Error<string>("What did you do?!");
+
+// Or with multiple messages:
+var multipleErrors = new Error<string>(new[] {
+    "Database connection failed",
+    "Retry attempts exhausted"
+});
 ```
 
 That's really all there is to creating a result instance, but what about handling a result instance?

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Sample/Examples.cs
@@ -64,14 +64,26 @@ public class Examples
         };
     }
     
+    public string NoErrorsPatternMatchingMultipleErrorMessages()
+    {
+        // No error here as the pattern matching covers all of the possibilities.
+        var workResult = Result<string>.Error(["The file didn't exist.", "The path was incorrect."]);
+
+        return workResult switch
+        {
+            Ok<string> => "ok",
+            Error<string> => "error",
+        };
+    }
+    
     public string ErrorBecauseTheSwitchStatementIsntExhaustive()
     {
         // Error here as the switch statement doesn't handles all cases. 
         var workResult = DoWork();
-        
+
         Result<string>.Error("The file didn't exist.");
-        
-        var whatever =  workResult switch
+
+        var whatever = workResult switch
         {
             Error<string> => "error"
         };

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/NonGenericResultHandlingAnalyzerTests.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/NonGenericResultHandlingAnalyzerTests.cs
@@ -122,7 +122,7 @@ public class NonGenericResultHandlingAnalyzerTests
 
                 if (result is Error error)
                 {
-                    Console.WriteLine(error.Message);
+                    Console.WriteLine(error.Messages[0]);
                 }
             }
 

--- a/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/ResultHandlingAnalyzerTests.cs
+++ b/Tombatron.Results.Analyzers/Tombatron.Results.Analyzers.Tests/ResultHandlingAnalyzerTests.cs
@@ -122,7 +122,7 @@ public class ResultHandlingAnalyzerTests
 
                 if (result is Error<int> error)
                 {
-                    Console.WriteLine(error.Message);
+                    Console.WriteLine(error.Messages[0]);
                 }
             }
 

--- a/Tombatron.Results.Tests/ResultsTests.cs
+++ b/Tombatron.Results.Tests/ResultsTests.cs
@@ -1,0 +1,323 @@
+using Tombatron.Results;
+
+namespace Tombatron.Results.Tests;
+
+public class ResultsTests
+{
+    public class GenericResultTests
+    {
+        [Fact]
+        public void Ok_WithValue_ShouldReturnOkResult()
+        {
+            var result = Result<string>.Ok("test");
+            
+            Assert.IsType<Ok<string>>(result);
+        }
+
+        [Fact]
+        public void Error_WithSingleMessage_ShouldReturnErrorResult()
+        {
+            var result = Result<string>.Error("error message");
+            
+            Assert.IsType<Error<string>>(result);
+            var error = (Error<string>)result;
+            Assert.Single(error.Messages);
+            Assert.Equal("error message", error.Messages[0]);
+        }
+
+        [Fact]
+        public void Error_WithMultipleMessages_ShouldReturnErrorResult()
+        {
+            var messages = new[] { "error 1", "error 2", "error 3" };
+            var result = Result<string>.Error(messages);
+            
+            Assert.IsType<Error<string>>(result);
+            var error = (Error<string>)result;
+            Assert.Equal(3, error.Messages.Length);
+            Assert.Equal(messages, error.Messages);
+        }
+
+        [Fact]
+        public void Unwrap_WhenOk_ShouldReturnValue()
+        {
+            var result = Result<int>.Ok(42);
+            
+            var value = result.Unwrap();
+            
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void Unwrap_WhenErrorWithSingleMessage_ShouldThrowResultUnwrapException()
+        {
+            var result = Result<string>.Error("test error");
+            
+            var exception = Assert.Throws<ResultUnwrapException>(() => result.Unwrap());
+            Assert.Contains("test error", exception.Message);
+        }
+
+        [Fact]
+        public void Unwrap_WhenErrorWithMultipleMessages_ShouldThrowResultUnwrapAggregateException()
+        {
+            var messages = new[] { "error 1", "error 2", "error 3" };
+            var result = Result<string>.Error(messages);
+            
+            var exception = Assert.Throws<ResultUnwrapAggregateException>(() => result.Unwrap());
+            Assert.Equal(3, exception.InnerExceptions.Count);
+            
+            var innerMessages = exception.InnerExceptions.Select(e => e.Message).ToArray();
+            Assert.Contains("error 1", innerMessages);
+            Assert.Contains("error 2", innerMessages);
+            Assert.Contains("error 3", innerMessages);
+        }
+
+        [Fact]
+        public void UnwrapOr_WhenOk_ShouldReturnValue()
+        {
+            var result = Result<int>.Ok(42);
+            
+            var value = result.UnwrapOr(0);
+            
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void UnwrapOr_WhenError_ShouldReturnDefaultValue()
+        {
+            var result = Result<int>.Error("error");
+            
+            var value = result.UnwrapOr(99);
+            
+            Assert.Equal(99, value);
+        }
+    }
+
+    public class NonGenericResultTests
+    {
+        [Fact]
+        public void Ok_ShouldReturnOkResult()
+        {
+            var result = Result.Ok;
+            
+            Assert.IsType<Ok>(result);
+        }
+
+        [Fact]
+        public void Error_WithSingleMessage_ShouldReturnErrorResult()
+        {
+            var result = Result.Error("error message");
+            
+            Assert.IsType<Error>(result);
+            var error = (Error)result;
+            Assert.Single(error.Messages);
+            Assert.Equal("error message", error.Messages[0]);
+        }
+
+        [Fact]
+        public void Error_WithMultipleMessages_ShouldReturnErrorResult()
+        {
+            var messages = new[] { "error 1", "error 2", "error 3" };
+            var result = Result.Error(messages);
+            
+            Assert.IsType<Error>(result);
+            var error = (Error)result;
+            Assert.Equal(3, error.Messages.Length);
+            Assert.Equal(messages, error.Messages);
+        }
+    }
+
+    public class OkGenericTests
+    {
+        [Fact]
+        public void Constructor_WithValue_ShouldStoreValue()
+        {
+            var ok = new Ok<string>("test value");
+            
+            Assert.Equal("test value", ok.Value);
+        }
+
+        [Fact]
+        public void Value_ShouldReturnStoredValue()
+        {
+            var testObject = new { Name = "Test", Value = 42 };
+            var ok = new Ok<object>(testObject);
+            
+            Assert.Same(testObject, ok.Value);
+        }
+    }
+
+    public class ErrorGenericTests
+    {
+        [Fact]
+        public void Constructor_WithSingleMessage_ShouldCreateArrayWithOneMessage()
+        {
+            var error = new Error<string>("single error");
+            
+            Assert.Single(error.Messages);
+            Assert.Equal("single error", error.Messages[0]);
+        }
+
+        [Fact]
+        public void Constructor_WithMessageArray_ShouldStoreMessages()
+        {
+            var messages = new[] { "error 1", "error 2", "error 3" };
+            var error = new Error<string>(messages);
+            
+            Assert.Equal(messages, error.Messages);
+        }
+
+        [Fact]
+        public void Constructor_WithEmptyArray_ShouldThrowArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Error<string>([]));
+        }
+    }
+
+    public class ErrorNonGenericTests
+    {
+        [Fact]
+        public void Constructor_WithSingleMessage_ShouldCreateArrayWithOneMessage()
+        {
+            var error = new Error("single error");
+            
+            Assert.Single(error.Messages);
+            Assert.Equal("single error", error.Messages[0]);
+        }
+
+        [Fact]
+        public void Constructor_WithMessageArray_ShouldStoreMessages()
+        {
+            var messages = new[] { "error 1", "error 2", "error 3" };
+            var error = new Error(messages);
+            
+            Assert.Equal(messages, error.Messages);
+        }
+
+        [Fact]
+        public void Constructor_WithEmptyArray_ShouldThrowArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Error([]));
+        }
+    }
+
+    public class ResultUnwrapExceptionTests
+    {
+        [Fact]
+        public void Constructor_WithMessage_ShouldSetMessage()
+        {
+            var exception = new ResultUnwrapException("test message");
+            
+            Assert.Equal("test message", exception.Message);
+        }
+
+        [Fact]
+        public void ShouldInheritFromException()
+        {
+            var exception = new ResultUnwrapException("test");
+            
+            Assert.IsAssignableFrom<Exception>(exception);
+        }
+    }
+
+    public class ResultUnwrapAggregateExceptionTests
+    {
+        [Fact]
+        public void Constructor_WithMessageAndInnerExceptions_ShouldSetProperties()
+        {
+            var innerExceptions = new[]
+            {
+                new ResultUnwrapException("error 1"),
+                new ResultUnwrapException("error 2")
+            };
+            
+            var exception = new ResultUnwrapAggregateException("aggregate message", innerExceptions);
+            
+            Assert.Contains("aggregate message", exception.Message);
+            Assert.Equal(2, exception.InnerExceptions.Count);
+            Assert.Contains(innerExceptions[0], exception.InnerExceptions);
+            Assert.Contains(innerExceptions[1], exception.InnerExceptions);
+        }
+
+        [Fact]
+        public void ShouldInheritFromAggregateException()
+        {
+            var exception = new ResultUnwrapAggregateException("test", []);
+            
+            Assert.IsAssignableFrom<AggregateException>(exception);
+        }
+    }
+
+    public class EdgeCaseTests
+    {
+        [Fact]
+        public void Result_WithNonNullConstraint_ShouldWorkWithReferenceTypes()
+        {
+            var result = Result<string>.Ok("test");
+            
+            Assert.Equal("test", result.Unwrap());
+        }
+
+        [Fact]
+        public void Result_WithNonNullConstraint_ShouldWorkWithValueTypes()
+        {
+            var result = Result<int>.Ok(42);
+            
+            Assert.Equal(42, result.Unwrap());
+        }
+
+        [Fact]
+        public void Result_WithNonNullConstraint_ShouldWorkWithCustomTypes()
+        {
+            var testObj = new { Name = "Test", Id = 1 };
+            var result = Result<object>.Ok(testObj);
+            
+            Assert.Same(testObj, result.Unwrap());
+        }
+
+        [Fact]
+        public void UnwrapOr_WithComplexTypes_ShouldWork()
+        {
+            var defaultList = new List<int> { 1, 2, 3 };
+            var errorResult = Result<List<int>>.Error("failed to get list");
+            
+            var result = errorResult.UnwrapOr(defaultList);
+            
+            Assert.Same(defaultList, result);
+        }
+
+        [Fact]
+        public void Error_Messages_ShouldBeReadOnly()
+        {
+            var error = new Error<string>("test");
+            var messages = error.Messages;
+            
+            Assert.IsType<string[]>(messages);
+            Assert.Single(messages);
+        }
+
+        [Fact]
+        public void Multiple_Unwrap_Calls_ShouldBehaveConsistently()
+        {
+            var result = Result<int>.Ok(42);
+            
+            Assert.Equal(42, result.Unwrap());
+            Assert.Equal(42, result.Unwrap());
+            Assert.Equal(42, result.Unwrap());
+        }
+
+        [Fact]
+        public void Error_With_LargeNumberOfMessages_ShouldWork()
+        {
+            var messages = Enumerable.Range(1, 1000)
+                .Select(i => $"Error {i}")
+                .ToArray();
+            
+            var result = Result<string>.Error(messages);
+            var error = (Error<string>)result;
+            
+            Assert.Equal(1000, error.Messages.Length);
+            Assert.Equal("Error 1", error.Messages[0]);
+            Assert.Equal("Error 1000", error.Messages[999]);
+        }
+    }
+}

--- a/Tombatron.Results.Tests/Tombatron.Results.Tests.csproj
+++ b/Tombatron.Results.Tests/Tombatron.Results.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tombatron.Results\Tombatron.Results.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tombatron.Results.sln
+++ b/Tombatron.Results.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tombatron.Results.Analyzers", "Tombatron.Results.Analyzers\Tombatron.Results.Analyzers\Tombatron.Results.Analyzers.csproj", "{CD38B75C-1D21-41E9-BAE8-F63169211AF2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tombatron.Results.Analyzers.Sample", "Tombatron.Results.Analyzers\Tombatron.Results.Analyzers.Sample\Tombatron.Results.Analyzers.Sample.csproj", "{2C1E7EEF-3E76-4F48-946B-45A91A38BA01}"
@@ -9,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tombatron.Results", "Tombatron.Results\Tombatron.Results.csproj", "{E67D4396-7DA6-4831-B56E-E435CD9956BB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tombatron.Results.All", "Tombatron.Results.All\Tombatron.Results.All.csproj", "{56B9377A-3D74-4802-9ECB-AEA49994181F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tombatron.Results.Tests", "Tombatron.Results.Tests\Tombatron.Results.Tests.csproj", "{BDC4962A-847C-4DB0-B525-7C2F14BF93E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,5 +38,9 @@ Global
 		{56B9377A-3D74-4802-9ECB-AEA49994181F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{56B9377A-3D74-4802-9ECB-AEA49994181F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{56B9377A-3D74-4802-9ECB-AEA49994181F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDC4962A-847C-4DB0-B525-7C2F14BF93E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDC4962A-847C-4DB0-B525-7C2F14BF93E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDC4962A-847C-4DB0-B525-7C2F14BF93E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDC4962A-847C-4DB0-B525-7C2F14BF93E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Tombatron.Results/Error.cs
+++ b/Tombatron.Results/Error.cs
@@ -1,11 +1,15 @@
 ﻿namespace Tombatron.Results;
 
-public class Error<T>(string message) : Result<T> where T : notnull
+public class Error<T>(string[] messages) : Result<T> where T : notnull
 {
-    public string Message => message;
+    public Error(string message) : this([message]) { }
+
+    public string[] Messages => messages;
 }
 
-public class Error(string message) : Result
+public class Error(IEnumerable<string> messages) : Result
 {
-    public string Message => message;
+    public Error(string message) : this([message]) { }
+
+    public IEnumerable<string> Messages => messages;
 }

--- a/Tombatron.Results/Error.cs
+++ b/Tombatron.Results/Error.cs
@@ -4,12 +4,32 @@ public class Error<T>(string[] messages) : Result<T> where T : notnull
 {
     public Error(string message) : this([message]) { }
 
-    public string[] Messages => messages;
+    public string[] Messages { get; } = ValidateMessages(messages);
+
+    private static string[] ValidateMessages(string[] messages)
+    {
+        if (messages is not {Length: > 0})
+        {
+            throw new ArgumentException("At least one error message is required", nameof(messages));
+        }
+
+        return messages;
+    }
 }
 
 public class Error(string[] messages) : Result
 {
     public Error(string message) : this([message]) { }
 
-    public string[] Messages => messages;
+    public string[] Messages { get; } = ValidateMessages(messages);
+
+    private static string[] ValidateMessages(string[] messages)
+    {
+        if (messages is not {Length: > 0})
+        {
+            throw new ArgumentException("At least one error message is required", nameof(messages));
+        }
+
+        return messages;
+    }
 }

--- a/Tombatron.Results/Error.cs
+++ b/Tombatron.Results/Error.cs
@@ -7,9 +7,9 @@ public class Error<T>(string[] messages) : Result<T> where T : notnull
     public string[] Messages => messages;
 }
 
-public class Error(IEnumerable<string> messages) : Result
+public class Error(string[] messages) : Result
 {
     public Error(string message) : this([message]) { }
 
-    public IEnumerable<string> Messages => messages;
+    public string[] Messages => messages;
 }

--- a/Tombatron.Results/Result.cs
+++ b/Tombatron.Results/Result.cs
@@ -7,21 +7,43 @@ public class Result<T> where T : notnull
     public static Result<T> Ok(T value) => 
         new Ok<T>(value);
     
+    public static Result<T> Error(string[] messages) => 
+        new Error<T>(messages);
+        
     public static Result<T> Error(string message) => 
-        new Error<T>(message);
+        new Error<T>([message]);
 
-    public T Unwrap() => this is Ok<T> ok 
-        ? ok.Value 
-        : throw new ResultUnwrapException($"[ERROR] [{GetType().Name}]: {(this is Error<T> e ? e.Message : "Unexpected result type.")}");
-    
-    public T UnwrapOr(T defaultValue) => 
+    public T Unwrap()
+    {
+        if (this is Ok<T> ok)
+        {
+            return ok.Value;
+        }
+
+        if (this is Error<T> error)
+        {
+            if (error.Messages.Length == 1)
+            {
+                throw new ResultUnwrapException($"[ERROR] [{GetType().Name}]: {error.Messages[0]}");
+            }
+
+            throw new ResultUnwrapAggregateException($"[MULTIPLE ERRORS] [{GetType().Name}]", error.Messages.Select(m => new ResultUnwrapException(m)));
+        }
+
+        throw new ResultUnwrapException($"[ERROR] [{GetType().Name}]: Unexpected result type.");
+    }
+
+    public T UnwrapOr(T defaultValue) =>
         this is Ok<T> ok ? ok.Value : defaultValue;    
 }
 
 public abstract class Result
 {
     public static readonly Result Ok = new Ok();
-    
-    public static Result Error(string message) => 
-        new Error(message);
+
+    public static Result Error(string message) =>
+        new Error([message]);
+        
+    public static Result Error(IEnumerable<string> messages) => 
+        new Error(messages);
 }

--- a/Tombatron.Results/Result.cs
+++ b/Tombatron.Results/Result.cs
@@ -35,6 +35,6 @@ public abstract class Result
     public static Result Error(string message) =>
         new Error([message]);
         
-    public static Result Error(IEnumerable<string> messages) => 
+    public static Result Error(string[] messages) => 
         new Error(messages);
 }

--- a/Tombatron.Results/ResultUnwrapAggregateException.cs
+++ b/Tombatron.Results/ResultUnwrapAggregateException.cs
@@ -1,0 +1,5 @@
+namespace Tombatron.Results;
+
+public class ResultUnwrapAggregateException(string message, IEnumerable<Exception> innerExceptions) : AggregateException(message, innerExceptions)
+{
+}


### PR DESCRIPTION
Since users may have more than one message they would like to wrap in a single error, then 'Error' may be best suited to accept multiple messages:

```csharp
var multipleErrors = Result<string>.Error(new[] { 
    "Validation failed for field 'Name'", 
    "Validation failed for field 'Email'", 
    "Validation failed for field 'Phone'" 
});
```

In this case, if Unwrap is called then it will throw a ResultUnwrapAggregateException.